### PR TITLE
Add Docker image for Linux; 'docs' target for building PDFs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:19.10
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install --yes --no-install-recommends \
+    tcl \
+    tk \
+    pandoc \
+    make \
+    gcc \
+    g++ \
+    texlive-latex-recommended \
+    texlive-fonts-recommended

--- a/Makefile
+++ b/Makefile
@@ -230,3 +230,8 @@ board/P2ES_flashloader.bin: bin/fastspin board/P2ES_flashloader.spin2
 board/P2ES_flashloader.spin2: loadp2/board/P2ES_flashloader.spin2
 	mkdir -p board
 	cp loadp2/board/P2ES_flashloader.spin2 $@
+
+docs: $(PDFFILES)
+
+docker:
+	docker build -t flexguibuilder .


### PR DESCRIPTION
This should make it easier and more reliable to build Linux packages